### PR TITLE
fix: plex life cycle regression

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -30,17 +30,19 @@ void Application::setupDiscordCallbacks()
         } else {
             m_trayIcon->setConnectionStatus("Status: Connecting to Plex...");
         }
+#endif
         m_plex->init();
-#endif
         std::unique_lock<std::mutex> lock(m_discordConnectMutex);
-        m_discordConnectCv.notify_all(); });
+        m_discordConnectCv.notify_all();
+                                    });
 
+        m_discord->setDisconnectedCallback([this]()
+                                           {
+            m_plex->stop();
 #ifdef _WIN32
-    m_discord->setDisconnectedCallback([this]()
-                                       { 
-                                        m_plex->stop();
-                                        m_trayIcon->setConnectionStatus("Status: Waiting for Discord..."); });
+            m_trayIcon->setConnectionStatus("Status: Waiting for Discord...");
 #endif
+                                           });
 }
 
 bool Application::initialize()


### PR DESCRIPTION
Introduced on https://github.com/abarnes6/plex-presence/commit/bc3b9289a4c3c6273f0e2b38a2e966d9a5379d23 I think this was just a mistake. 

The `m_plex->init();` and `m_plex->stop();` be calling only for Windows makes the app not starting (or stopping gracefully to write configs)